### PR TITLE
Fix spaces escaping in params

### DIFF
--- a/make-aliases.sh
+++ b/make-aliases.sh
@@ -12,7 +12,7 @@ for exe in $(ls /home/wine/wix | grep .exe$); do
 
     cat > $binpath/$name << EOF
 #!/bin/sh
-wine /home/wine/wix/$exe \$@
+wine /home/wine/wix/$exe "\$@"
 EOF
     chmod +x $binpath/$name
 done


### PR DESCRIPTION
candle -dMY_VAR_WITH_SPACES="MY VAR" throws an error without this fix